### PR TITLE
updates controls to more closely resemble vim.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,7 +230,7 @@ checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
 
 [[package]]
 name = "slingshot-term"
-version = "0.2.3"
+version = "0.3.0"
 dependencies = [
  "crossterm",
  "phf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slingshot-term"
-version = "0.2.3"
+version = "0.3.0"
 authors = ["Caio Ishikawa <caio.ishikawa@proton.me"]
 edition = "2021"
 license = "MIT"

--- a/Formula/slingshot.rb
+++ b/Formula/slingshot.rb
@@ -1,0 +1,16 @@
+class Slingshot < Formula
+  desc "Lightweight command line application with vim-like keybinds for quick file navigation."
+  homepage "https://github.com/caio-ishikawa/slingshot"
+  url "https://github.com/caio-ishikawa/slingshot/archive/refs/tags/v0.3.0.tar.gz"
+  sha256 "65168f65612f82f2a0ed6faa7bf6e20fd141f5788219bcbd6c695ef92d2ea35b"
+
+  depends_on "rust" => :build
+
+  def install
+    system "make", "install"
+  end
+
+  test do
+    system "cargo", "test"
+  end
+end

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-slingshot 0.2.3
+slingshot 0.3.0
 ===============
 
 [![Tests](https://github.com/caio-ishikawa/slingshot/actions/workflows/build.yml/badge.svg?branch=master)](https://github.com/caio-ishikawa/slingshot/actions/workflows/build.yml)
@@ -20,9 +20,6 @@ Dependencies
 
 How to install
 --------------
-- Cargo installation:
-    - Run  `cargo install slingshot-term`.
-
 - Build from source:
     - Clone the repository & navigate to cloned directory.
     - Run `make build`
@@ -30,22 +27,22 @@ How to install
 
 How to use
 ----------
-- Moving up/down:
-    - Arrow Keys
-    - `Ctrl+J`/`Ctrl+K`
+Slingshot aims to closely resemble vim motions to ensure a coherent workflow. 
+Once started, Slingshot defaults to `normal mode`.
 
-- Creating folders/files:
-    - For folders, type the desired name followed by a `/`.
-    - For files, type the name of the desired file with the file extension (e.g. `.py`, `.txt`, etc.)
-    - Confirm creation by pressing Enter.
+Normal mode:
+- Used for navigation.
+- [J, K] can be used to navigate up and down the file list.
+- [H, L] can be used to navigate back one directory, or to enter the selected directory.
+- [I, A] can be used to switch to `insert mode`
 
-- Deleting files/folders:
-    - Marking files/folders for deletion is done by pressing Ctrl+D, which will highlight the item red.
-    - Confirm by pressing `Ctrl+Y`.
+Insert mode:
+- Used for typing the search term. 
+- [Enter] can be used to enter the selected file.
 
-- Command mode:
-    - Toggling between Command Mode and File Explorer can be done by pressing `Ctrl+N`.
-    - To run the command, type it and confirm with Enter.
+Global commands:
+- [`Ctrl+C`] to quit application,
+- [`Ctrl+N`] to run commands.
 
 Fish Shell Integration
 ----------------------

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -1,11 +1,68 @@
-use crate::state_handler;
+use crate::state_handler::{AppState, KeybindMode};
 use crossterm;
 use crossterm::event::{KeyCode, KeyModifiers};
 use std::error::Error;
 
-pub fn handle_key_code(
+pub fn handle_key(key_code: KeyCode, app_state: &mut AppState) -> Result<(), Box<dyn Error>> {
+    match app_state.keybind_mode {
+        KeybindMode::Normal => handle_normal_mode(key_code, app_state),
+        KeybindMode::Insert => handle_key_code_insert(key_code, app_state),
+        _ => Ok(()),
+    }
+}
+
+fn handle_normal_mode(key_code: KeyCode, app_state: &mut AppState) -> Result<(), Box<dyn Error>> {
+    match key_code {
+        KeyCode::Char('i') => {
+            app_state.keybind_mode = KeybindMode::Insert;
+            return Ok(());
+        }
+        KeyCode::Char('a') => {
+            app_state.keybind_mode = KeybindMode::Insert;
+            return Ok(());
+        }
+        KeyCode::Char('h') => {
+            app_state.handle_move_back();
+            return Ok(());
+        }
+        KeyCode::Char('j') => {
+            app_state.update_selected_index(KeyCode::Down);
+            return Ok(());
+        }
+        KeyCode::Char('k') => {
+            app_state.update_selected_index(KeyCode::Up);
+            return Ok(());
+        }
+        KeyCode::Char('l') => {
+            app_state.handle_enter();
+            return Ok(());
+        }
+        KeyCode::Char('d') => {
+            app_state.handle_mark_delete();
+            return Ok(());
+        }
+        KeyCode::Char('y') => {
+            app_state.handle_confirm_delete();
+            return Ok(());
+        }
+        KeyCode::Char('n') => {
+            app_state.toggle_command_mode();
+            return Ok(());
+        }
+        KeyCode::Enter => {
+            app_state.handle_enter();
+            return Ok(());
+        }
+        _ => {
+            app_state.handle_unsupported_input();
+            return Ok(());
+        }
+    }
+}
+
+pub fn handle_key_code_insert(
     key_code: KeyCode,
-    app_state: &mut state_handler::AppState,
+    app_state: &mut AppState,
 ) -> Result<(), Box<dyn Error>> {
     match key_code {
         KeyCode::Char(c) => {
@@ -29,8 +86,12 @@ pub fn handle_key_code(
             return Ok(());
         }
         KeyCode::Esc => {
-            crossterm::terminal::disable_raw_mode()?;
-            std::process::exit(0);
+            if app_state.displayed_paths.len() == 0 {
+                app_state.user_input = "".to_owned();
+                app_state.displayed_paths = app_state.inner_paths.clone();
+            }
+            app_state.keybind_mode = KeybindMode::Normal;
+            return Ok(());
         }
         _ => return Ok(()),
     }
@@ -39,7 +100,7 @@ pub fn handle_key_code(
 pub fn handle_key_modifier(
     key_code: KeyCode,
     modifier: KeyModifiers,
-    app_state: &mut state_handler::AppState,
+    app_state: &mut AppState,
 ) -> Result<(), Box<dyn Error>> {
     if modifier == KeyModifiers::CONTROL {
         match key_code {
@@ -47,28 +108,8 @@ pub fn handle_key_modifier(
                 crossterm::terminal::disable_raw_mode()?;
                 std::process::exit(0);
             }
-            KeyCode::Char('k') => {
-                app_state.update_selected_index(KeyCode::Up);
-                return Ok(());
-            }
-            KeyCode::Char('j') => {
-                app_state.update_selected_index(KeyCode::Down);
-                return Ok(());
-            }
-            KeyCode::Char('d') => {
-                app_state.handle_mark_delete();
-                return Ok(());
-            }
-            KeyCode::Char('y') => {
-                app_state.handle_confirm_delete();
-                return Ok(());
-            }
             KeyCode::Char('n') => {
                 app_state.toggle_command_mode();
-                return Ok(());
-            }
-            KeyCode::Char('h') => {
-                app_state.handle_move_back();
                 return Ok(());
             }
             _ => {
@@ -85,9 +126,10 @@ pub fn handle_key_modifier(
 mod integration_tests {
     use super::*;
     use crate::file;
+    use crate::state_handler::AppMode;
     use std::path::Path;
 
-    fn enter_test_dir() -> state_handler::AppState {
+    fn enter_test_dir() -> AppState {
         let test_dir_path = "tests";
         let curr_dir = std::env::current_dir().expect("Could not get current dir");
         let absolute_path = curr_dir
@@ -99,8 +141,9 @@ mod integration_tests {
         let paths = std::fs::read_dir(&absolute_path).expect("Could not find paths");
         let formatted_paths = file::generate_file_data(paths).expect("Error generating file data");
 
-        return state_handler::AppState {
-            mode: state_handler::AppMode::FileExplorer,
+        return AppState {
+            mode: AppMode::FileExplorer,
+            keybind_mode: KeybindMode::Normal,
             curr_absolute_path: absolute_path,
             inner_paths: formatted_paths.clone(),
             displayed_paths: formatted_paths.clone(),
@@ -121,11 +164,11 @@ mod integration_tests {
             .map(|fd| fd.shortname.clone())
             .collect();
 
-        handle_key_code(KeyCode::Char('l'), &mut state).unwrap();
+        handle_key_code_insert(KeyCode::Char('l'), &mut state).unwrap();
         assert_eq!(state.displayed_paths.len(), 1);
         assert_eq!(&state.displayed_paths[0].shortname, "llkh.py");
 
-        handle_key_code(KeyCode::Backspace, &mut state).unwrap();
+        handle_key_code_insert(KeyCode::Backspace, &mut state).unwrap();
         for file in state.clone().displayed_paths {
             assert_eq!(
                 initial_state_displayed_paths.contains(&file.shortname),
@@ -135,7 +178,7 @@ mod integration_tests {
 
         let new_input = ['d', 'i', 'r', '1'];
         for ch in new_input {
-            handle_key_code(KeyCode::Char(ch), &mut state).unwrap();
+            handle_key_code_insert(KeyCode::Char(ch), &mut state).unwrap();
         }
 
         assert_eq!(state.displayed_paths.len(), 1);
@@ -143,18 +186,18 @@ mod integration_tests {
         let previous_dir = state.clone().curr_absolute_path.to_owned();
         let selected = state.clone().displayed_paths[0].to_owned().absolute;
 
-        handle_key_code(KeyCode::Enter, &mut state).unwrap();
+        handle_key_code_insert(KeyCode::Enter, &mut state).unwrap();
         assert_eq!(state.curr_absolute_path, selected);
 
-        handle_key_code(KeyCode::Left, &mut state).unwrap();
+        handle_key_code_insert(KeyCode::Left, &mut state).unwrap();
         assert_eq!(state.curr_absolute_path, previous_dir);
 
         let new_input = ['t', 'e', 's', 't', 'i', 'n', 'g', '.', 'p', 'y'];
         for ch in new_input {
-            handle_key_code(KeyCode::Char(ch), &mut state).unwrap();
+            handle_key_code_insert(KeyCode::Char(ch), &mut state).unwrap();
         }
 
-        handle_key_code(KeyCode::Enter, &mut state).unwrap();
+        handle_key_code_insert(KeyCode::Enter, &mut state).unwrap();
         println!("created file");
 
         let path_list: Vec<String> = state
@@ -176,8 +219,9 @@ mod integration_tests {
             .position(|fd| fd.shortname.as_str() == "testing.py")
             .unwrap();
 
-        handle_key_modifier(KeyCode::Char('d'), KeyModifiers::CONTROL, &mut state).unwrap();
-        handle_key_modifier(KeyCode::Char('y'), KeyModifiers::CONTROL, &mut state).unwrap();
+        handle_normal_mode(KeyCode::Char('d'), &mut state).unwrap();
+        handle_normal_mode(KeyCode::Char('y'), &mut state).unwrap();
+        println!("Deleted file");
 
         let includes_added_file: Vec<&str> = state
             .inner_paths
@@ -188,17 +232,17 @@ mod integration_tests {
         assert_eq!(includes_added_file.len(), 0);
 
         handle_key_modifier(KeyCode::Char('n'), KeyModifiers::CONTROL, &mut state).unwrap();
-        assert_eq!(state.mode, state_handler::AppMode::Command);
+        assert_eq!(state.mode, AppMode::Command);
 
         let new_input = ['e', 'c', 'h', 'o', ' ', 't', 'e', 's', 't'];
         for ch in new_input {
-            handle_key_code(KeyCode::Char(ch), &mut state).unwrap();
+            handle_key_code_insert(KeyCode::Char(ch), &mut state).unwrap();
         }
 
-        handle_key_code(KeyCode::Enter, &mut state).unwrap();
+        handle_key_code_insert(KeyCode::Enter, &mut state).unwrap();
         assert_eq!(state.message, "test".to_owned());
 
         handle_key_modifier(KeyCode::Char('n'), KeyModifiers::CONTROL, &mut state).unwrap();
-        assert_eq!(state.mode, state_handler::AppMode::FileExplorer);
+        assert_eq!(state.mode, AppMode::FileExplorer);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,28 +1,33 @@
+use std::error::Error;
+use std::panic;
+use std::time::Duration;
+
+use crossterm::event::{self, Event, KeyModifiers};
+
 mod event_handler;
 mod file;
 mod state_handler;
 mod styles;
 
-use crossterm::event::{self, KeyModifiers};
-use std::error::Error;
-use std::panic;
-
 fn start_slingshot(starting_state: &state_handler::AppState) -> Result<(), Box<dyn Error>> {
+    let polling_interval = Duration::from_millis(10);
     let mut app_state = starting_state.clone();
     app_state.display()?;
 
     loop {
-        if let event::Event::Key(key_event) = event::read()? {
-            if key_event.modifiers != KeyModifiers::NONE {
-                event_handler::handle_key_modifier(
-                    key_event.code,
-                    key_event.modifiers,
-                    &mut app_state,
-                )?;
-                app_state.display()?;
-            } else {
-                event_handler::handle_key_code(key_event.code, &mut app_state)?;
-                app_state.display()?;
+        if event::poll(polling_interval)? {
+            if let Event::Key(key_event) = event::read()? {
+                if key_event.modifiers != KeyModifiers::NONE {
+                    event_handler::handle_key_modifier(
+                        key_event.code,
+                        key_event.modifiers,
+                        &mut app_state,
+                    )?;
+                    app_state.display()?;
+                } else {
+                    event_handler::handle_key(key_event.code, &mut app_state)?;
+                    app_state.display()?;
+                }
             }
         }
     }

--- a/src/state_handler.rs
+++ b/src/state_handler.rs
@@ -28,7 +28,7 @@ pub enum AppMode {
 
 #[derive(Clone)]
 pub struct AppState {
-    pub app_mode: AppMode, //TODO: Change this to app_mode
+    pub app_mode: AppMode,
     pub keybind_mode: KeybindMode,
     pub curr_absolute_path: String,
     pub inner_paths: Vec<file::FileData>,

--- a/src/state_handler.rs
+++ b/src/state_handler.rs
@@ -28,7 +28,7 @@ pub enum AppMode {
 
 #[derive(Clone)]
 pub struct AppState {
-    pub mode: AppMode, //TODO: Change this to app_mode
+    pub app_mode: AppMode, //TODO: Change this to app_mode
     pub keybind_mode: KeybindMode,
     pub curr_absolute_path: String,
     pub inner_paths: Vec<file::FileData>,
@@ -41,7 +41,7 @@ pub struct AppState {
 
 impl AppState {
     pub fn display(&self) -> Result<(), Box<dyn Error>> {
-        match self.mode {
+        match self.app_mode {
             AppMode::FileExplorer => {
                 print!("{esc}[2J{esc}[1;1H", esc = 27 as char);
                 let mut stdout = stdout();
@@ -207,7 +207,7 @@ impl AppState {
     }
 
     pub fn handle_enter(&mut self) {
-        match self.mode {
+        match self.app_mode {
             AppMode::FileExplorer => self.handle_enter_explorer(),
             AppMode::Command => self.handle_enter_command(),
         }
@@ -265,9 +265,9 @@ impl AppState {
         self.message = String::from("");
         self.update_paths();
 
-        match self.mode {
-            AppMode::FileExplorer => self.mode = AppMode::Command,
-            AppMode::Command => self.mode = AppMode::FileExplorer,
+        match self.app_mode {
+            AppMode::FileExplorer => self.app_mode = AppMode::Command,
+            AppMode::Command => self.app_mode = AppMode::FileExplorer,
         }
     }
 
@@ -314,7 +314,7 @@ pub fn initial_app_state() -> Result<AppState, Box<dyn Error>> {
     let formatted_paths = file::generate_file_data(paths).unwrap();
 
     return Ok(AppState {
-        mode: AppMode::FileExplorer,
+        app_mode: AppMode::FileExplorer,
         keybind_mode: KeybindMode::Normal,
         curr_absolute_path: cwd.to_owned(),
         inner_paths: formatted_paths.clone(),
@@ -352,7 +352,7 @@ mod tests {
         let test_file_data = gen_test_file_data(test_file_names);
 
         let mut app_state = AppState {
-            mode: AppMode::FileExplorer,
+            app_mode: AppMode::FileExplorer,
             keybind_mode: KeybindMode::Normal,
             curr_absolute_path: "/Test/test_dir/".to_owned(),
             inner_paths: test_file_data.clone(),
@@ -409,7 +409,7 @@ mod tests {
         let test_file_data = gen_test_file_data(test_file_names);
 
         let mut app_state = AppState {
-            mode: AppMode::FileExplorer,
+            app_mode: AppMode::FileExplorer,
             keybind_mode: KeybindMode::Normal,
             curr_absolute_path: "/Test/test_dir/".to_owned(),
             inner_paths: test_file_data.clone(),

--- a/src/state_handler.rs
+++ b/src/state_handler.rs
@@ -13,6 +13,14 @@ use std::io::{stdout, Write};
 use std::process::Command;
 
 #[derive(Clone, Debug, PartialEq)]
+pub enum KeybindMode {
+    Normal,
+    Insert,
+    //Visual,
+    //Deletion,
+}
+
+#[derive(Clone, Debug, PartialEq)]
 pub enum AppMode {
     FileExplorer,
     Command,
@@ -20,7 +28,8 @@ pub enum AppMode {
 
 #[derive(Clone)]
 pub struct AppState {
-    pub mode: AppMode,
+    pub mode: AppMode, //TODO: Change this to app_mode
+    pub keybind_mode: KeybindMode,
     pub curr_absolute_path: String,
     pub inner_paths: Vec<file::FileData>,
     pub displayed_paths: Vec<file::FileData>,
@@ -57,6 +66,9 @@ impl AppState {
                 );
 
                 print!("{}", self.user_input);
+                if self.keybind_mode == KeybindMode::Normal {
+                    stdout.queue(cursor::MoveTo(0, (self.selected_index + 1) as u16))?;
+                }
                 stdout.flush()?;
             }
             AppMode::Command => {
@@ -303,6 +315,7 @@ pub fn initial_app_state() -> Result<AppState, Box<dyn Error>> {
 
     return Ok(AppState {
         mode: AppMode::FileExplorer,
+        keybind_mode: KeybindMode::Normal,
         curr_absolute_path: cwd.to_owned(),
         inner_paths: formatted_paths.clone(),
         displayed_paths: formatted_paths.clone(),
@@ -340,6 +353,7 @@ mod tests {
 
         let mut app_state = AppState {
             mode: AppMode::FileExplorer,
+            keybind_mode: KeybindMode::Normal,
             curr_absolute_path: "/Test/test_dir/".to_owned(),
             inner_paths: test_file_data.clone(),
             displayed_paths: test_file_data,
@@ -396,6 +410,7 @@ mod tests {
 
         let mut app_state = AppState {
             mode: AppMode::FileExplorer,
+            keybind_mode: KeybindMode::Normal,
             curr_absolute_path: "/Test/test_dir/".to_owned(),
             inner_paths: test_file_data.clone(),
             displayed_paths: test_file_data,


### PR DESCRIPTION
With this change, Slingshot will start in "normal mode", which allows the user to move up, down, back, and forward in the file list using H,J,K & L. To start insert mode, which allows the user to edit the search term, either the "a" key or the "i" key will trigger it to start.

Ctrl+N continues to be the key used for starting command mode.

I chose to create a new field in the AppState to represent the different vim-like modes because I eventually want to be able to use both visual and insert mode in the command screen. It would be useful to be able to copy the output of commands to the clipboard.